### PR TITLE
corrected command to install ens160 on device

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install ens160
+    circup install adafruit_ens160
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
Made a minor correction in the README. The previous command `circup install ens160` would throw an error: 
`ens160 is not a known CircuitPython library.`

The correct command should be `circup install adafruit_ens160`