### PR TITLE
removed reset() and MODE_IDLE from constructor

### DIFF
--- a/adafruit_ens160.py
+++ b/adafruit_ens160.py
@@ -106,11 +106,8 @@ class ENS160:
     def __init__(self, i2c_bus: I2C, address: int = ENS160_I2CADDR_DEFAULT) -> None:
         self.i2c_device = i2c_device.I2CDevice(i2c_bus, address)
 
-        self.reset()
-
         if self.part_id != 0x160:
             raise RuntimeError("Unable to find ENS160, check your wiring")
-        self.mode = MODE_IDLE
         self.clear_command()
         self.mode = MODE_STANDARD
         self._buf = bytearray(8)


### PR DESCRIPTION
This PR removes the call to `self.reset()` and the switch to `MODE_IDLE` from the constructor.

Both statements are at best harmless, but in important use-cases harmful. The ENS160 has an internal timer for the warmup period after POR (three minutes). Resetting or switching to idle-mode resets this timer.

After power-on, the call to `reset()` is redundant, since the device is in reset mode anyhow. Otherwise, the call will reset the timer although this is not necessary. In my use-case, I sample data in intervals and use deep-sleep in between. Deep sleep keeps the device powered (at least on the Pico (W)), so only an initial warm up period is necessary. But after exiting from deep sleep the program (and the constructor) run again and this driver resets the timer causing a wait of three minutes every iteration.

If there is really a need for a reset, the method can be called any time explicitly.